### PR TITLE
Add client-side mock data generator application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# mock-data-generator
-mock
+# Mock Data Generator
+
+Tarayıcı üzerinde çalışan Mock Data Generator uygulaması; JSON Schema, SQL `CREATE TABLE` scriptleri veya manuel alan tanımlarından sahte veri üretmeye yardımcı olur. Uygulama tamamıyla client-side çalışır ve oluşturulan veriler hiçbir sunucuya gönderilmez.
+
+## Özellikler
+
+- **JSON Schema modu:** Draft-07 uyumlu şemalardan json-schema-faker ile veri üretir, AJV ile doğrular.
+- **CREATE TABLE modu:** SQL tablo tanımını çözümler, kolon tiplerini/kısıtları algılar ve INSERT script’leri oluşturur.
+- **Manual modu:** Alan adı, veri tipi ve kısıtları manuel girerek JSON Schema oluşturur.
+- **Edge case üretimi:** İsteğe bağlı olarak sınır değerlerini deneyen kayıtlar ekler ve doğrulama hatalarını raporlar.
+- **Dışa aktarma:** JSON, CSV veya SQL formatında veri indirme seçenekleri sunar.
+- **Önizleme:** İlk 20 kaydı tablo ve JSON formatında görüntüler.
+
+## Geliştirme
+
+```bash
+npm install
+npm run dev
+```
+
+> Not: Çevrimdışı ortamda çalışıyorsanız `npm install` komutu kayıtlı npm mirror’larına erişemeyebilir.
+
+## Derleme
+
+```bash
+npm run build
+```
+
+## Lisans
+
+MIT

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mock Data Generator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mock-data-generator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ajv": "^8.12.0",
+    "ajv-formats": "^3.0.1",
+    "json-schema-faker": "^0.5.0-rcv.57",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,304 @@
+import { useMemo, useState } from 'react';
+import type { GeneratorMode, ManualField } from './types';
+import ManualFieldEditor from './components/ManualFieldEditor';
+import { parseCreateTableScript } from './utils/sqlParser';
+import { manualFieldsToSchema } from './utils/manualSchema';
+import { generateRecords } from './utils/generator';
+import { downloadCsv, downloadJson, downloadSql, toJsonString } from './utils/exporters';
+
+const modeLabels: Record<GeneratorMode, string> = {
+  jsonSchema: 'JSON Schema',
+  createTable: 'CREATE TABLE',
+  manual: 'Manuel Tanım',
+};
+
+const initialSchema = `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": { "type": "integer", "minimum": 1 },
+    "name": { "type": "string", "minLength": 3 },
+    "email": { "type": "string", "format": "email" }
+  },
+  "required": ["id", "name", "email"]
+}`;
+
+const initialCreateTable = `CREATE TABLE users (
+  id INTEGER NOT NULL,
+  full_name VARCHAR(100) NOT NULL,
+  email VARCHAR(150) NOT NULL,
+  age INTEGER CHECK (age >= 18)
+);`;
+
+function createManualField(): ManualField {
+  return {
+    id: Math.random().toString(36).slice(2),
+    name: '',
+    type: 'string',
+    required: true,
+  };
+}
+
+function getDefaultInput(mode: GeneratorMode): string {
+  if (mode === 'jsonSchema') return initialSchema;
+  if (mode === 'createTable') return initialCreateTable;
+  return '';
+}
+
+export default function App() {
+  const [mode, setMode] = useState<GeneratorMode>('jsonSchema');
+  const [definition, setDefinition] = useState<string>(getDefaultInput('jsonSchema'));
+  const [manualFields, setManualFields] = useState<ManualField[]>([createManualField()]);
+  const [recordCount, setRecordCount] = useState<number>(5);
+  const [includeEdgeCases, setIncludeEdgeCases] = useState<boolean>(false);
+  const [records, setRecords] = useState<any[]>([]);
+  const [tableName, setTableName] = useState<string>('mock_data');
+  const [isGenerating, setIsGenerating] = useState<boolean>(false);
+  const [schemaErrors, setSchemaErrors] = useState<string[]>([]);
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+
+  const manualSchemaPreview = useMemo(() => {
+    if (mode !== 'manual') return '';
+    const { schema } = manualFieldsToSchema(manualFields);
+    return JSON.stringify(schema, null, 2);
+  }, [manualFields, mode]);
+
+  const handleModeChange = (value: GeneratorMode) => {
+    setMode(value);
+    if (value === 'manual') {
+      setRecords([]);
+      setSchemaErrors([]);
+      return;
+    }
+    setDefinition(getDefaultInput(value));
+    setRecords([]);
+    setSchemaErrors([]);
+  };
+
+  const handleManualFieldChange = (nextField: ManualField) => {
+    setManualFields((previous) => previous.map((field) => (field.id === nextField.id ? nextField : field)));
+  };
+
+  const handleManualFieldRemove = (id: string) => {
+    setManualFields((previous) => previous.filter((field) => field.id !== id));
+  };
+
+  const addManualField = () => {
+    setManualFields((previous) => [...previous, createManualField()]);
+  };
+
+  const resolveSchema = (): { schema: any; errors: string[]; table?: string } => {
+    if (mode === 'jsonSchema') {
+      try {
+        const schema = JSON.parse(definition);
+        return { schema, errors: [] };
+      } catch (error) {
+        return { schema: null, errors: ['JSON Schema parse edilemedi: ' + (error as Error).message] };
+      }
+    }
+    if (mode === 'createTable') {
+      const { schema, errors, tableName: parsedTableName } = parseCreateTableScript(definition);
+      if (parsedTableName) {
+        setTableName(parsedTableName);
+      }
+      return { schema, errors, table: parsedTableName };
+    }
+    const { schema, errors } = manualFieldsToSchema(manualFields);
+    return { schema, errors };
+  };
+
+  const handleGenerate = async () => {
+    const { schema, errors, table } = resolveSchema();
+    setSchemaErrors(errors);
+    if (!schema || errors.length > 0) {
+      return;
+    }
+    setIsGenerating(true);
+    try {
+      const { records: generated, validationErrors: validation } = await generateRecords(schema, recordCount, includeEdgeCases);
+      setRecords(generated);
+      setValidationErrors(validation);
+      if (table) {
+        setTableName(table);
+      }
+    } catch (error) {
+      setSchemaErrors([(error as Error).message]);
+      setRecords([]);
+      setValidationErrors([]);
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const previewRecords = useMemo(() => records.slice(0, 20), [records]);
+  const previewColumns = useMemo(() => {
+    const set = new Set<string>();
+    previewRecords.forEach((record) => {
+      Object.keys(record || {}).forEach((key) => set.add(key));
+    });
+    return Array.from(set);
+  }, [previewRecords]);
+  const jsonPreview = useMemo(() => (previewRecords.length ? toJsonString(previewRecords) : ''), [previewRecords]);
+
+  const exportDisabled = records.length === 0;
+
+  return (
+    <div className="app">
+      <header className="app__header">
+        <div>
+          <h1>Mock Data Generator</h1>
+          <p>JSON Schema, SQL veya manuel tanımlardan hızlıca sahte veri üretin.</p>
+        </div>
+        <div className="mode-selector">
+          {(Object.keys(modeLabels) as GeneratorMode[]).map((key) => (
+            <button
+              key={key}
+              className={key === mode ? 'active' : ''}
+              type="button"
+              onClick={() => handleModeChange(key)}
+            >
+              {modeLabels[key]}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <main className="layout">
+        <section className="panel">
+          <div className="panel__header">
+            <h2>Yapı Tanımı</h2>
+            <div className="panel__actions">
+              <label>
+                Kayıt sayısı
+                <input
+                  type="number"
+                  min={1}
+                  max={1000}
+                  value={recordCount}
+                  onChange={(event) => setRecordCount(Math.min(1000, Math.max(1, Number(event.target.value))))}
+                />
+              </label>
+              <label className="edge-checkbox">
+                <input
+                  type="checkbox"
+                  checked={includeEdgeCases}
+                  onChange={(event) => setIncludeEdgeCases(event.target.checked)}
+                />
+                Edge case üret
+              </label>
+              <button type="button" onClick={handleGenerate} disabled={isGenerating}>
+                {isGenerating ? 'Üretiliyor…' : 'Veri Üret'}
+              </button>
+            </div>
+          </div>
+          {mode !== 'manual' ? (
+            <textarea
+              value={definition}
+              onChange={(event) => setDefinition(event.target.value)}
+              spellCheck={false}
+              className="schema-input"
+              rows={18}
+            />
+          ) : (
+            <div className="manual-editor">
+              {manualFields.map((field) => (
+                <ManualFieldEditor
+                  key={field.id}
+                  field={field}
+                  onChange={handleManualFieldChange}
+                  onRemove={handleManualFieldRemove}
+                />
+              ))}
+              <button type="button" className="add-field" onClick={addManualField}>
+                Alan Ekle
+              </button>
+              <div className="manual-preview">
+                <h3>Oluşan JSON Schema</h3>
+                <pre>{manualSchemaPreview}</pre>
+              </div>
+            </div>
+          )}
+          {schemaErrors.length > 0 && (
+            <div className="error-box">
+              <h3>Tanım Hataları</h3>
+              <ul>
+                {schemaErrors.map((error) => (
+                  <li key={error}>{error}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
+
+        <section className="panel">
+          <div className="panel__header">
+            <h2>Önizleme & Dışa Aktarım</h2>
+            <div className="panel__actions">
+              <button type="button" onClick={() => downloadJson(records)} disabled={exportDisabled}>
+                JSON indir
+              </button>
+              <button type="button" onClick={() => downloadCsv(records)} disabled={exportDisabled}>
+                CSV indir
+              </button>
+              <button
+                type="button"
+                onClick={() => downloadSql(records, tableName || 'mock_data')}
+                disabled={exportDisabled}
+              >
+                SQL INSERT indir
+              </button>
+            </div>
+          </div>
+          {records.length === 0 ? (
+            <p className="empty">Henüz veri üretilmedi.</p>
+          ) : (
+            <>
+              <div className="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      {previewColumns.map((column) => (
+                        <th key={column}>{column}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {previewRecords.map((record, index) => (
+                      <tr key={index}>
+                        {previewColumns.map((column) => (
+                          <td key={column}>{formatCell(record[column])}</td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <details>
+                <summary>JSON Önizlemesi</summary>
+                <pre className="json-preview">{jsonPreview}</pre>
+              </details>
+            </>
+          )}
+          {validationErrors.length > 0 && (
+            <div className="warning-box">
+              <h3>Validasyon Uyarıları</h3>
+              <ul>
+                {validationErrors.map((error, index) => (
+                  <li key={`${error}-${index}`}>{error}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function formatCell(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}

--- a/src/components/ManualFieldEditor.tsx
+++ b/src/components/ManualFieldEditor.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react';
+import type { ManualField } from '../types';
+
+interface ManualFieldEditorProps {
+  field: ManualField;
+  onChange: (field: ManualField) => void;
+  onRemove: (id: string) => void;
+}
+
+const numericTypes = new Set(['number', 'integer']);
+
+export default function ManualFieldEditor({ field, onChange, onRemove }: ManualFieldEditorProps) {
+  const requiresNumericConstraints = useMemo(() => numericTypes.has(field.type), [field.type]);
+  const requiresStringConstraints = useMemo(() => field.type === 'string', [field.type]);
+
+  const handleChange = (key: keyof ManualField, value: unknown) => {
+    onChange({ ...field, [key]: value });
+  };
+
+  return (
+    <div className="manual-field">
+      <div className="manual-field__header">
+        <strong>{field.name || 'Yeni Alan'}</strong>
+        <button type="button" onClick={() => onRemove(field.id)}>
+          Sil
+        </button>
+      </div>
+      <div className="manual-field__grid">
+        <label>
+          Alan Adı
+          <input value={field.name} onChange={(event) => handleChange('name', event.target.value)} />
+        </label>
+        <label>
+          Veri Tipi
+          <select value={field.type} onChange={(event) => handleChange('type', event.target.value)}>
+            <option value="string">String</option>
+            <option value="number">Number</option>
+            <option value="integer">Integer</option>
+            <option value="boolean">Boolean</option>
+            <option value="date">Date</option>
+          </select>
+        </label>
+        <label className="manual-field__checkbox">
+          <input
+            type="checkbox"
+            checked={field.required}
+            onChange={(event) => handleChange('required', event.target.checked)}
+          />
+          Zorunlu
+        </label>
+        {requiresStringConstraints && (
+          <>
+            <label>
+              Min. Uzunluk
+              <input
+                type="number"
+                min={0}
+                value={field.minLength ?? ''}
+                onChange={(event) => handleChange('minLength', event.target.value ? Number(event.target.value) : undefined)}
+              />
+            </label>
+            <label>
+              Max. Uzunluk
+              <input
+                type="number"
+                min={0}
+                value={field.maxLength ?? ''}
+                onChange={(event) => handleChange('maxLength', event.target.value ? Number(event.target.value) : undefined)}
+              />
+            </label>
+            <label>
+              Pattern (RegExp)
+              <input
+                value={field.pattern ?? ''}
+                onChange={(event) => handleChange('pattern', event.target.value || undefined)}
+                placeholder="^[A-Z]{3}$"
+              />
+            </label>
+            <label>
+              Enum (virgülle ayrılmış)
+              <input
+                value={field.enumValues ?? ''}
+                onChange={(event) => handleChange('enumValues', event.target.value)}
+                placeholder="A, B, C"
+              />
+            </label>
+          </>
+        )}
+        {requiresNumericConstraints && (
+          <>
+            <label>
+              Minimum
+              <input
+                type="number"
+                value={field.minimum ?? ''}
+                onChange={(event) => handleChange('minimum', event.target.value ? Number(event.target.value) : undefined)}
+              />
+            </label>
+            <label>
+              Maksimum
+              <input
+                type="number"
+                value={field.maximum ?? ''}
+                onChange={(event) => handleChange('maximum', event.target.value ? Number(event.target.value) : undefined)}
+              />
+            </label>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,305 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  background: #f1f5f9;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+}
+
+textarea {
+  font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.app__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.app__header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+}
+
+.app__header p {
+  margin: 0;
+  color: #475569;
+}
+
+.mode-selector {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.mode-selector button {
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  background: white;
+  font-weight: 600;
+  color: #1e293b;
+  transition: all 0.2s ease;
+}
+
+.mode-selector button.active {
+  background: #2563eb;
+  color: white;
+  border-color: #2563eb;
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.2);
+}
+
+.mode-selector button:hover {
+  border-color: #2563eb;
+}
+
+.layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .layout {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.panel {
+  background: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 20px 30px -20px rgba(15, 23, 42, 0.2);
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.panel__header h2 {
+  margin: 0;
+}
+
+.panel__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.panel__actions label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.panel__actions input[type='number'] {
+  margin-top: 0.25rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5f5;
+}
+
+.panel__actions button {
+  background: #2563eb;
+  color: white;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  box-shadow: 0 10px 20px -15px rgba(37, 99, 235, 0.6);
+}
+
+.panel__actions button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.edge-checkbox {
+  flex-direction: row !important;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.schema-input {
+  width: 100%;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  padding: 1rem;
+  background: #f8fafc;
+  resize: vertical;
+  min-height: 420px;
+}
+
+.manual-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.manual-field {
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.manual-field__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.manual-field__header button {
+  background: none;
+  border: none;
+  color: #ef4444;
+}
+
+.manual-field__grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.manual-field__grid label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.manual-field__grid input,
+.manual-field__grid select {
+  margin-top: 0.3rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5f5;
+  background: white;
+}
+
+.manual-field__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.add-field {
+  align-self: flex-start;
+  background: #0f172a;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+}
+
+.manual-preview {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  overflow: auto;
+  max-height: 240px;
+}
+
+.manual-preview pre {
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.table-wrapper {
+  max-height: 320px;
+  overflow: auto;
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+th,
+td {
+  padding: 0.75rem;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+th {
+  background: #f8fafc;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.json-preview {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  overflow: auto;
+  max-height: 300px;
+  font-size: 0.85rem;
+}
+
+.error-box,
+.warning-box {
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.error-box {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.warning-box {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.empty {
+  color: #64748b;
+  margin: 2rem 0;
+  text-align: center;
+}
+
+details summary {
+  cursor: pointer;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,32 @@
+export type GeneratorMode = 'jsonSchema' | 'createTable' | 'manual';
+
+export interface ManualField {
+  id: string;
+  name: string;
+  type: 'string' | 'number' | 'integer' | 'boolean' | 'date';
+  required: boolean;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  minimum?: number;
+  maximum?: number;
+  enumValues?: string;
+}
+
+export interface ColumnDefinition {
+  name: string;
+  type: string;
+  notNull: boolean;
+  checks: ColumnCheck[];
+}
+
+export type ColumnCheck =
+  | { kind: 'min'; value: number }
+  | { kind: 'max'; value: number }
+  | { kind: 'pattern'; value: string };
+
+export interface SchemaGenerationResult {
+  schema: unknown;
+  tableName?: string;
+  errors: string[];
+}

--- a/src/utils/exporters.ts
+++ b/src/utils/exporters.ts
@@ -1,0 +1,69 @@
+import { saveAs } from './fileSaver';
+
+export function toJsonString(records: any[]): string {
+  return JSON.stringify(records, null, 2);
+}
+
+export function toCsvString(records: any[]): string {
+  if (!records.length) {
+    return '';
+  }
+  const headers = Array.from(
+    records.reduce((set, record) => {
+      Object.keys(record || {}).forEach((key) => set.add(key));
+      return set;
+    }, new Set<string>()),
+  );
+  const escape = (value: unknown) => {
+    if (value == null) return '';
+    const stringValue = typeof value === 'string' ? value : JSON.stringify(value);
+    if (stringValue.includes(',') || stringValue.includes('\n') || stringValue.includes('"')) {
+      return `"${stringValue.replace(/"/g, '""')}"`;
+    }
+    return stringValue;
+  };
+  const rows = records.map((record) => headers.map((header) => escape((record || {})[header])).join(','));
+  return [headers.join(','), ...rows].join('\n');
+}
+
+export function toSqlInsert(records: any[], tableName: string): string {
+  if (!records.length) {
+    return '';
+  }
+  const rows = records
+    .map((record) => {
+      const columns = Object.keys(record);
+      const values = columns
+        .map((column) => formatSqlValue(record[column]))
+        .join(', ');
+      return `INSERT INTO ${tableName} (${columns.join(', ')}) VALUES (${values});`;
+    })
+    .join('\n');
+  return rows;
+}
+
+function formatSqlValue(value: unknown): string {
+  if (value == null || Number.isNaN(value)) {
+    return 'NULL';
+  }
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return String(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'TRUE' : 'FALSE';
+  }
+  const stringValue = typeof value === 'string' ? value : JSON.stringify(value);
+  return `'${stringValue.replace(/'/g, "''")}';
+}
+
+export function downloadJson(records: any[], filename = 'mock-data.json'): void {
+  saveAs(new Blob([toJsonString(records)], { type: 'application/json' }), filename);
+}
+
+export function downloadCsv(records: any[], filename = 'mock-data.csv'): void {
+  saveAs(new Blob([toCsvString(records)], { type: 'text/csv' }), filename);
+}
+
+export function downloadSql(records: any[], tableName: string, filename = 'mock-data.sql'): void {
+  saveAs(new Blob([toSqlInsert(records, tableName)], { type: 'text/plain' }), filename);
+}

--- a/src/utils/fileSaver.ts
+++ b/src/utils/fileSaver.ts
@@ -1,0 +1,9 @@
+export function saveAs(blob: Blob, filename: string): void {
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}

--- a/src/utils/generator.ts
+++ b/src/utils/generator.ts
@@ -1,0 +1,119 @@
+import jsf from 'json-schema-faker';
+import Ajv, { ErrorObject } from 'ajv';
+import addFormats from 'ajv-formats';
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+
+jsf.option({
+  alwaysFakeOptionals: true,
+  fillProperties: true,
+  useExamplesValue: true,
+  useDefaultValue: true,
+});
+
+export interface GenerationOutcome {
+  records: any[];
+  validationErrors: string[];
+}
+
+function makeEdgeCaseValue(schema: any): unknown {
+  if (!schema) return null;
+  const { type } = schema;
+  if (Array.isArray(type)) {
+    return makeEdgeCaseValue({ ...schema, type: type.find((t) => t !== 'null') });
+  }
+  switch (type) {
+    case 'string': {
+      if (schema.minLength != null && schema.minLength > 0) {
+        return 'a'.repeat(Math.max(0, schema.minLength - 1));
+      }
+      if (schema.maxLength != null) {
+        return 'a'.repeat(schema.maxLength + 1);
+      }
+      if (schema.enum) {
+        return 'unexpected-value';
+      }
+      if (schema.pattern) {
+        return 'pattern-mismatch';
+      }
+      if (schema.format === 'date' || schema.format === 'date-time') {
+        return '';
+      }
+      return '';
+    }
+    case 'number':
+    case 'integer': {
+      if (schema.minimum != null) {
+        return schema.minimum - 1;
+      }
+      if (schema.maximum != null) {
+        return schema.maximum + 1;
+      }
+      return Number.NaN;
+    }
+    case 'boolean':
+      return null;
+    case 'array':
+      if (schema.minItems && schema.minItems > 0) {
+        return [];
+      }
+      return [{}];
+    case 'object': {
+      const edgeRecord: Record<string, unknown> = {};
+      if (schema.properties) {
+        Object.entries(schema.properties).forEach(([key, childSchema]) => {
+          edgeRecord[key] = makeEdgeCaseValue(childSchema);
+        });
+      }
+      return edgeRecord;
+    }
+    default:
+      return null;
+  }
+}
+
+function createEdgeCaseRecord(schema: any): Record<string, unknown> {
+  if (!schema || schema.type !== 'object') {
+    return {};
+  }
+  const record: Record<string, unknown> = {};
+  if (schema.properties) {
+    Object.entries(schema.properties).forEach(([key, propertySchema]) => {
+      record[key] = makeEdgeCaseValue(propertySchema);
+    });
+  }
+  return record;
+}
+
+function formatAjvError(error: ErrorObject): string {
+  const path = error.instancePath || error.schemaPath;
+  const message = error.message || 'geçersiz değer';
+  return `${path} ${message}`;
+}
+
+export async function generateRecords(schema: any, count: number, edgeCases: boolean): Promise<GenerationOutcome> {
+  const records: any[] = [];
+  const generator = async () => jsf.resolve(schema);
+  for (let i = 0; i < count; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const record = await generator();
+    records.push(record);
+  }
+  if (edgeCases) {
+    records.push(createEdgeCaseRecord(schema));
+  }
+
+  const validator = ajv.compile(schema);
+  const validationErrors: string[] = [];
+  records.forEach((record, index) => {
+    const valid = validator(record);
+    if (!valid && validator.errors) {
+      validator.errors.forEach((error) => {
+        validationErrors.push(`Satır ${index + 1}: ${formatAjvError(error)}`);
+      });
+    }
+  });
+
+  return { records, validationErrors };
+}

--- a/src/utils/manualSchema.ts
+++ b/src/utils/manualSchema.ts
@@ -1,0 +1,55 @@
+import type { ManualField, SchemaGenerationResult } from '../types';
+
+export function manualFieldsToSchema(fields: ManualField[]): SchemaGenerationResult {
+  const properties: Record<string, any> = {};
+  const required: string[] = [];
+  const errors: string[] = [];
+
+  fields.forEach((field) => {
+    if (!field.name.trim()) {
+      errors.push('İsimsiz alanlar yok sayıldı.');
+      return;
+    }
+    const schema: Record<string, unknown> = { type: field.type === 'date' ? 'string' : field.type };
+    if (field.type === 'date') {
+      schema.format = 'date-time';
+    }
+    if (field.minLength != null) {
+      schema.minLength = field.minLength;
+    }
+    if (field.maxLength != null) {
+      schema.maxLength = field.maxLength;
+    }
+    if (field.pattern) {
+      schema.pattern = field.pattern;
+    }
+    if (field.minimum != null) {
+      schema.minimum = field.minimum;
+    }
+    if (field.maximum != null) {
+      schema.maximum = field.maximum;
+    }
+    if (field.enumValues) {
+      const values = field.enumValues
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+      if (values.length > 0) {
+        schema.enum = values;
+      }
+    }
+    properties[field.name] = schema;
+    if (field.required) {
+      required.push(field.name);
+    }
+  });
+
+  const schema = {
+    type: 'object',
+    additionalProperties: false,
+    properties,
+    required
+  };
+
+  return { schema, errors };
+}

--- a/src/utils/sqlParser.ts
+++ b/src/utils/sqlParser.ts
@@ -1,0 +1,181 @@
+import type { ColumnCheck, ColumnDefinition, SchemaGenerationResult } from '../types';
+
+const typeMap: Record<string, { type: string; format?: string; minLength?: number; maxLength?: number }> = {
+  int: { type: 'integer' },
+  integer: { type: 'integer' },
+  smallint: { type: 'integer' },
+  bigint: { type: 'integer' },
+  real: { type: 'number' },
+  double: { type: 'number' },
+  float: { type: 'number' },
+  decimal: { type: 'number' },
+  numeric: { type: 'number' },
+  money: { type: 'number' },
+  boolean: { type: 'boolean' },
+  bool: { type: 'boolean' },
+  text: { type: 'string' },
+  varchar: { type: 'string' },
+  char: { type: 'string' },
+  nchar: { type: 'string' },
+  nvarchar: { type: 'string' },
+  date: { type: 'string', format: 'date' },
+  datetime: { type: 'string', format: 'date-time' },
+  timestamp: { type: 'string', format: 'date-time' }
+};
+
+function normaliseIdentifier(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith('`') && trimmed.endsWith('`'))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function splitColumnDefinitions(columnsSection: string): string[] {
+  const result: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (let i = 0; i < columnsSection.length; i += 1) {
+    const char = columnsSection[i];
+    if (char === '(') {
+      depth += 1;
+    } else if (char === ')') {
+      depth = Math.max(0, depth - 1);
+    } else if (char === ',' && depth === 0) {
+      result.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim().length > 0) {
+    result.push(current.trim());
+  }
+  return result;
+}
+
+function parseColumnDefinition(definition: string): ColumnDefinition | null {
+  const trimmed = definition.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const upper = trimmed.toUpperCase();
+  if (upper.startsWith('PRIMARY KEY') || upper.startsWith('CONSTRAINT') || upper.startsWith('FOREIGN KEY')) {
+    return null;
+  }
+
+  const tokens = trimmed.split(/\s+/);
+  if (tokens.length < 2) {
+    return null;
+  }
+  const name = normaliseIdentifier(tokens[0]);
+  const typeToken = tokens[1].toLowerCase();
+
+  let baseType = typeToken;
+  let lengthMatch: RegExpMatchArray | null = null;
+  const lengthRegex = /([a-zA-Z]+)\((\d+)\)/;
+  const lengthResult = typeToken.match(lengthRegex);
+  if (lengthResult) {
+    baseType = lengthResult[1];
+    lengthMatch = lengthResult;
+  }
+
+  const mapping = typeMap[baseType];
+  const notNull = upper.includes('NOT NULL');
+  const checks: ColumnCheck[] = [];
+  if (lengthMatch && mapping?.type === 'string') {
+    const length = Number(lengthMatch[2]);
+    checks.push({ kind: 'max', value: length });
+  }
+
+  const checkMatches = trimmed.match(/CHECK\s*\(([^)]+)\)/gi) || [];
+  checkMatches.forEach((segment) => {
+    const content = segment.replace(/CHECK\s*\(/i, '').replace(/\)$/i, '').trim();
+    const comparison = content.match(/([\w"`]+)\s*(<=|>=|<|>|=)\s*([\w'.-]+)/);
+    if (comparison) {
+      const [, column, operator, valueToken] = comparison;
+      if (normaliseIdentifier(column) === name) {
+        const numericValue = Number(valueToken.replace(/'/g, ''));
+        if (!Number.isNaN(numericValue)) {
+          if (operator === '>=' || operator === '>') {
+            checks.push({ kind: 'min', value: operator === '>' ? numericValue + 1 : numericValue });
+          } else if (operator === '<=' || operator === '<') {
+            checks.push({ kind: 'max', value: operator === '<' ? numericValue - 1 : numericValue });
+          }
+        }
+      }
+    }
+  });
+
+  return {
+    name,
+    type: baseType,
+    notNull,
+    checks
+  };
+}
+
+export function parseCreateTableScript(script: string): SchemaGenerationResult {
+  const errors: string[] = [];
+  const cleaned = script.replace(/;\s*$/g, '').trim();
+  const match = cleaned.match(/CREATE\s+TABLE\s+([\w"`]+)\s*\(([\s\S]+)\)/i);
+  if (!match) {
+    return { schema: null, errors: ['CREATE TABLE ifadesi çözümlenemedi.'], tableName: undefined };
+  }
+
+  const [, rawTableName, columnsSection] = match;
+  const tableName = normaliseIdentifier(rawTableName);
+  const columnDefinitions = splitColumnDefinitions(columnsSection)
+    .map(parseColumnDefinition)
+    .filter((column): column is ColumnDefinition => Boolean(column));
+
+  if (columnDefinitions.length === 0) {
+    errors.push('Tablo kolonları bulunamadı.');
+  }
+
+  const properties: Record<string, any> = {};
+  const required: string[] = [];
+
+  columnDefinitions.forEach((column) => {
+    const mapping = typeMap[column.type] || { type: 'string' };
+    const schema: Record<string, unknown> = { type: mapping.type };
+    if (mapping.format) {
+      schema.format = mapping.format;
+    }
+    column.checks.forEach((check) => {
+      if (check.kind === 'min') {
+        if (schema.type === 'string') {
+          schema.minLength = check.value;
+        } else {
+          schema.minimum = check.value;
+        }
+      }
+      if (check.kind === 'max') {
+        if (schema.type === 'string') {
+          schema.maxLength = check.value;
+        } else {
+          schema.maximum = check.value;
+        }
+      }
+      if (check.kind === 'pattern' && schema.type === 'string') {
+        schema.pattern = check.value;
+      }
+    });
+    if (mapping.type === 'string' && column.type === 'string') {
+      // no-op but keeps type inference happy
+    }
+    if (column.notNull) {
+      required.push(column.name);
+    }
+    properties[column.name] = schema;
+  });
+
+  const schema = {
+    type: 'object',
+    additionalProperties: false,
+    properties,
+    required
+  };
+
+  return { schema, tableName, errors };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- bootstrap a Vite + React client-only app for generating mock data from JSON Schema, SQL CREATE TABLE or manual field definitions
- add SQL parser, manual schema builder, json-schema-faker integration and edge case validation reporting
- provide export utilities for JSON, CSV and SQL along with polished UI and updated documentation

## Testing
- `npm install` *(fails: registry access returns 403 in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e54f5b72e0833389d144bcc1dfb6d7